### PR TITLE
trigger pedal noise just before the endpoints, instead of at them;

### DIFF
--- a/Data/pedal.txt
+++ b/Data/pedal.txt
@@ -3,11 +3,11 @@ lokey=-1
 hikey=-1
 
 <group> group_label=pedalD
-volume=-20 on_locc64=126 on_hicc64=127 group=1 off_by=2
+volume=-20 on_locc64=125 on_hicc64=126 group=1 off_by=2
 <region> region_label=1 lorand=0 hirand=0.5 sample=pedalD1.$EXT
 <region> region_label=2 lorand=0.5 hirand=1 sample=pedalD2.$EXT
 
 <group> group_label=pedalU
-volume=-19 on_locc64=0 on_hicc64=1 group=2
+volume=-19 on_locc64=1 on_hicc64=2 group=2
 <region> region_label=1 lorand=0 hirand=0.5 sample=pedalU1.$EXT
 <region> region_label=2 lorand=0.5 hirand=1 sample=pedalU2.$EXT


### PR DESCRIPTION
Previously sustain pedal noise was triggered at positions 0 (fully
released), and 1 (fully depressed).  If these values were sent
repeatedly, then the noise triggered constantly.